### PR TITLE
Fix favicon not loading by correcting MIME type

### DIFF
--- a/src/layouts/Head.astro
+++ b/src/layouts/Head.astro
@@ -10,7 +10,7 @@ const { title, description } = Astro.props;
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width" />
-  <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
   <meta name="generator" content={Astro.generator} />
   <meta name="description" content={description} />
   <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
Changed favicon type from image/svg+xml to image/x-icon to match the actual .ico file format. This resolves the favicon loading issue.